### PR TITLE
Debian Docker: Configure correct shell for hdm user

### DIFF
--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -14,10 +14,14 @@ class hdm::docker {
     ensure => present,
   }
 
+  $shell = $facts['os']['family'] ? {
+    'Debian' => '/usr/sbin/nologin',
+    'RedHat' => '/sbin/nologin',
+  }
   user { $hdm::user:
     ensure => present,
     gid    => $hdm::group,
-    shell  => '/sbin/nologin',
+    shell  => $shell,
   }
 
   $directories = [


### PR DESCRIPTION
This is cherry-picked from https://github.com/betadots/puppet-hdm/pull/19. The shell for the hdm user on Debian is different compared to RedHat. This commit fixes it. I verified it locally and it now works fine on Debian. The acceptance tests in #19 currently don't pass because the docker in docker in GHA setup doesn't work correctly.