### PR TITLE
add missing parameter for ldap

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -267,6 +267,7 @@ Needs the following Hash:
     'base_dn'          => 'ou=hdm,dc=nodomain',
     'bind_dn'          => 'cn=admin,dc=nodomain',
     'bind_dn_password' => 'openldap',
+    'ldaps'            =>  false,
   }
 ```
 
@@ -313,6 +314,7 @@ Struct[{
     Optional[base_dn]          => String[1],
     Optional[bind_dn]          => String[1],
     Optional[bind_dn_password] => String[1],
+    'ldaps'                    => Boolean,
   }]
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -236,7 +236,7 @@ Default value: ``true``
 
 ##### <a name="git_data"></a>`git_data`
 
-Data type: `Hdm::Gitdata`
+Data type: `Optional[Hdm::Gitdata]`
 
 Configure several settings related to the option
 to modify data via Webfrontend. WARNING!! untested!!
@@ -252,11 +252,11 @@ Required Array of hash data:
   ]
 ```
 
-Default value: `[]`
+Default value: ``undef``
 
 ##### <a name="ldap_settings"></a>`ldap_settings`
 
-Data type: `Hdm::Ldap_settings`
+Data type: `Optional[Hdm::Ldap_settings]`
 
 Config for LDAP integration
 Needs the following Hash:
@@ -271,7 +271,7 @@ Needs the following Hash:
   }
 ```
 
-Default value: `{}`
+Default value: ``undef``
 
 ##### <a name="hdm_hiera_config_file"></a>`hdm_hiera_config_file`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,7 @@
 #       'base_dn'          => 'ou=hdm,dc=nodomain',
 #       'bind_dn'          => 'cn=admin,dc=nodomain',
 #       'bind_dn_password' => 'openldap',
+#       'ldaps'            =>  false,
 #     }
 #   ```
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,10 +114,12 @@
 # @example
 #   include hdm
 class hdm (
+  # installation parameter
   Enum['docker', 'rvm']         $method                = 'docker',
   Boolean                       $manage_docker         = true,
   String[1]                     $version               = 'main',
   String[1]                     $ruby_version          = '3.1.2',
+  # required application parameter
   Stdlib::Port                  $port                  = 3000,
   Stdlib::IP::Address::Nosubnet $bind_ip               = '0.0.0.0',
   String[1]                     $hostname              = $facts['networking']['fqdn'],
@@ -129,10 +131,11 @@ class hdm (
   Hdm::Puppetdb                 $puppetdb_settings     = { 'server' => 'http://localhost:8080', },
   Stdlib::Unixpath              $puppet_code_dir       = '/etc/puppetlabs/code',
   String[1]                     $hdm_hiera_config_file = 'hiera.yaml',
+  # additional application parameter
   Boolean                       $allow_encryption      = false,
   Boolean                       $read_only             = true,
-  Hdm::Gitdata                  $git_data              = [],
-  Hdm::Ldap_settings            $ldap_settings         = {},
+  Optional[Hdm::Gitdata]        $git_data              = undef,
+  Optional[Hdm::Ldap_settings]  $ldap_settings         = undef,
 ) {
   case $method {
     'docker': {

--- a/types/ldap_settings.pp
+++ b/types/ldap_settings.pp
@@ -6,5 +6,6 @@ type Hdm::Ldap_settings = Struct[
     Optional[base_dn]          => String[1],
     Optional[bind_dn]          => String[1],
     Optional[bind_dn_password] => String[1],
+    'ldaps'                    => Boolean,
   }
 ]


### PR DESCRIPTION
when ldaps is used, hdm must be configured with `ldaps: true` 

if plain text ldap is used, the parameter can be omitted, or set to `false`

we prefer to always set the parameter.

fixes #23 